### PR TITLE
Wip/modular nu std/load all submodules

### DIFF
--- a/crates/nu-std/lib/mod.nu
+++ b/crates/nu-std/lib/mod.nu
@@ -1,13 +1,13 @@
 # std.nu, `used` to load all standard library components
 
-export use crates/nu-std/lib/assert.nu *
-export use crates/nu-std/lib/dirs.nu *
+export use assert *
+export use dirs *
 export-env {
-    use crates/nu-std/lib/dirs.nu *
+    use dirs *
 }
-export use crates/nu-std/lib/help.nu *
-export use crates/nu-std/lib/log.nu *
-export use crates/nu-std/lib/xml.nu *
+export use help *
+export use log *
+export use xml *
 
 # Add the given paths to the PATH.
 #

--- a/crates/nu-std/src/lib.rs
+++ b/crates/nu-std/src/lib.rs
@@ -2,8 +2,29 @@ use nu_parser::{parse, parse_module_block};
 use nu_protocol::report_error;
 use nu_protocol::{engine::StateWorkingSet, Module, ShellError, Span};
 
-fn get_standard_library() -> &'static str {
-    include_str!("../lib/mod.nu")
+fn add_file(
+    working_set: &mut StateWorkingSet,
+    name: &String,
+    content: &[u8],
+) -> (Module, Vec<Span>) {
+    let start = working_set.next_span_start();
+    working_set.add_file(name.clone(), content);
+    let end = working_set.next_span_start();
+
+    let (_, module, comments) =
+        parse_module_block(working_set, Span::new(start, end), name.as_bytes());
+
+    if let Some(err) = working_set.parse_errors.first() {
+        report_error(&working_set, err);
+    }
+
+    parse(working_set, Some(&name), content, true);
+
+    if let Some(err) = working_set.parse_errors.first() {
+        report_error(&working_set, err);
+    }
+
+    (module, comments)
 }
 
 fn load_prelude(working_set: &mut StateWorkingSet, prelude: Vec<(&str, &str)>, module: &Module) {
@@ -45,26 +66,14 @@ pub fn load_standard_library(
 ) -> Result<(), miette::ErrReport> {
     let delta = {
         let name = "std".to_string();
-        let content = get_standard_library().as_bytes();
 
         let mut working_set = StateWorkingSet::new(engine_state);
 
-        let start = working_set.next_span_start();
-        working_set.add_file(name.clone(), content);
-        let end = working_set.next_span_start();
-
-        let (_, module, comments) =
-            parse_module_block(&mut working_set, Span::new(start, end), name.as_bytes());
-
-        if let Some(err) = working_set.parse_errors.first() {
-            report_error(&working_set, err);
-        }
-
-        parse(&mut working_set, Some(&name), content, true);
-
-        if let Some(err) = working_set.parse_errors.first() {
-            report_error(&working_set, err);
-        }
+        let (module, comments) = add_file(
+            &mut working_set,
+            &name,
+            include_str!("../lib/mod.nu").as_bytes(),
+        );
 
         let prelude = vec![
             ("std help", "help"),

--- a/crates/nu-std/src/lib.rs
+++ b/crates/nu-std/src/lib.rs
@@ -67,7 +67,7 @@ pub fn load_standard_library(
     let delta = {
         let name = "std".to_string();
 
-        let modules = vec![
+        let submodules = vec![
             ("assert", include_str!("../lib/assert.nu")),
             ("dirs", include_str!("../lib/dirs.nu")),
             ("help", include_str!("../lib/help.nu")),
@@ -86,7 +86,7 @@ pub fn load_standard_library(
 
         let mut working_set = StateWorkingSet::new(engine_state);
 
-        for (name, content) in modules {
+        for (name, content) in submodules {
             let (module, comments) =
                 add_file(&mut working_set, &name.to_string(), content.as_bytes());
             working_set.add_module(&name, module, comments);

--- a/crates/nu-std/src/lib.rs
+++ b/crates/nu-std/src/lib.rs
@@ -67,8 +67,6 @@ pub fn load_standard_library(
     let delta = {
         let name = "std".to_string();
 
-        let mut working_set = StateWorkingSet::new(engine_state);
-
         let modules = vec![
             ("assert", include_str!("../lib/assert.nu")),
             ("dirs", include_str!("../lib/dirs.nu")),
@@ -76,6 +74,17 @@ pub fn load_standard_library(
             ("log", include_str!("../lib/log.nu")),
             ("xml", include_str!("../lib/xml.nu")),
         ];
+
+        let prelude = vec![
+            ("std help", "help"),
+            ("std help commands", "help commands"),
+            ("std help aliases", "help aliases"),
+            ("std help modules", "help modules"),
+            ("std help externs", "help externs"),
+            ("std help operators", "help operators"),
+        ];
+
+        let mut working_set = StateWorkingSet::new(engine_state);
 
         for (name, content) in modules {
             let (module, comments) =
@@ -88,18 +97,7 @@ pub fn load_standard_library(
             &name,
             include_str!("../lib/mod.nu").as_bytes(),
         );
-
-        let prelude = vec![
-            ("std help", "help"),
-            ("std help commands", "help commands"),
-            ("std help aliases", "help aliases"),
-            ("std help modules", "help modules"),
-            ("std help externs", "help externs"),
-            ("std help operators", "help operators"),
-        ];
-
         load_prelude(&mut working_set, prelude, &module);
-
         working_set.add_module(&name, module, comments);
 
         working_set.render()

--- a/crates/nu-std/src/lib.rs
+++ b/crates/nu-std/src/lib.rs
@@ -93,11 +93,7 @@ pub fn load_standard_library(
             working_set.add_module(&name, module, comments);
         }
 
-        let (module, comments) = add_file(
-            &mut working_set,
-            &name,
-            content.as_bytes(),
-        );
+        let (module, comments) = add_file(&mut working_set, &name, content.as_bytes());
         load_prelude(&mut working_set, prelude, &module);
         working_set.add_module(&name, module, comments);
 

--- a/crates/nu-std/src/lib.rs
+++ b/crates/nu-std/src/lib.rs
@@ -15,13 +15,13 @@ fn add_file(
         parse_module_block(working_set, Span::new(start, end), name.as_bytes());
 
     if let Some(err) = working_set.parse_errors.first() {
-        report_error(&working_set, err);
+        report_error(working_set, err);
     }
 
-    parse(working_set, Some(&name), content, true);
+    parse(working_set, Some(name), content, true);
 
     if let Some(err) = working_set.parse_errors.first() {
-        report_error(&working_set, err);
+        report_error(working_set, err);
     }
 
     (module, comments)
@@ -90,7 +90,7 @@ pub fn load_standard_library(
         for (name, content) in submodules {
             let (module, comments) =
                 add_file(&mut working_set, &name.to_string(), content.as_bytes());
-            working_set.add_module(&name, module, comments);
+            working_set.add_module(name, module, comments);
         }
 
         let (module, comments) = add_file(&mut working_set, &name, content.as_bytes());

--- a/crates/nu-std/src/lib.rs
+++ b/crates/nu-std/src/lib.rs
@@ -66,6 +66,7 @@ pub fn load_standard_library(
 ) -> Result<(), miette::ErrReport> {
     let delta = {
         let name = "std".to_string();
+        let content = include_str!("../lib/mod.nu");
 
         let submodules = vec![
             ("assert", include_str!("../lib/assert.nu")),
@@ -95,7 +96,7 @@ pub fn load_standard_library(
         let (module, comments) = add_file(
             &mut working_set,
             &name,
-            include_str!("../lib/mod.nu").as_bytes(),
+            content.as_bytes(),
         );
         load_prelude(&mut working_set, prelude, &module);
         working_set.add_module(&name, module, comments);

--- a/crates/nu-std/src/lib.rs
+++ b/crates/nu-std/src/lib.rs
@@ -69,6 +69,20 @@ pub fn load_standard_library(
 
         let mut working_set = StateWorkingSet::new(engine_state);
 
+        let modules = vec![
+            ("assert", include_str!("../lib/assert.nu")),
+            ("dirs", include_str!("../lib/dirs.nu")),
+            ("help", include_str!("../lib/help.nu")),
+            ("log", include_str!("../lib/log.nu")),
+            ("xml", include_str!("../lib/xml.nu")),
+        ];
+
+        for (name, content) in modules {
+            let (module, comments) =
+                add_file(&mut working_set, &name.to_string(), content.as_bytes());
+            working_set.add_module(&name, module, comments);
+        }
+
         let (module, comments) = add_file(
             &mut working_set,
             &name,


### PR DESCRIPTION
## state
main issues with the current https://github.com/nushell/nushell/pull/8815
- we cannot use `export use crates/nu-std/lib/<mod>.nu` in `crates/nu-std/lib/mod.nu` because `crates/nu-std/` is not available in the final binary => this will work locally only
- the submodules are not available after the startup with the current library loader

## this proposal
> **Note**
> - :green_circle: pros
> - :red_circle: cons
> - :black_circle: neutral

- :green_circle: passes all the CI
- :green_circle: allows to write a simple `export use <mod> *` in `crates/nu-std/lib/mod.nu`
- :green_circle: loads all submodules :black_circle: before the main `std`
- :red_circle: require to write
```rust
        let submodules = vec![
            ...
            ("<mod>", include_str!("../lib/<mod>.nu")),
            ...
        ];
```
in `crates/nu-std/src/lib.rs`